### PR TITLE
deal with old and new guides

### DIFF
--- a/R/sideCoord--utils.R
+++ b/R/sideCoord--utils.R
@@ -2,8 +2,14 @@
 
 panel_guides_grob <- function (guides, position, theme)
 {
-  guide <- guide_for_position(guides, position) %||% guide_none()
-  guide_gengrob(guide, theme)
+  if (!inherits(guides, "Guides")) {
+    guide <- guide_for_position(guides, position) %||% guide_none()
+    guide_gengrob(guide, theme)
+  } else {
+    pair <- guides$get_position(position)
+    pair$guide$draw(theme, params = pair$params)
+  }
+
 }
 
 as_ggside_axis <- function(x) {
@@ -23,9 +29,20 @@ guide_for_position <- function (guides, position)
 }
 
 ggside_panel_guides_grob <- function(guides, position, theme) {
-  guide <- guide_for_position(guides, position) %||% guide_none()
-  guide <- as_ggside_axis(guide)
-  guide_gengrob(guide, theme)
+  if (inherits(guides, "Guides")) {
+    pair <- guides$get_position(position)
+    # # To use new guide system activate the line below
+    # pair$guide$draw(theme, params = pair$params)
+    # # And deactivate the line below up until the `} else {` line
+    if (inherits(pair$params$angle, "waiver")) {
+      pair$params$angle <- NULL
+    }
+    guide_gengrob.ggside_axis(pair$params, theme)
+  } else {
+    guide <- guide_for_position(guides, position) %||% guide_none()
+    guide <- as_ggside_axis(guide)
+    guide_gengrob(guide, theme)
+  }
 }
 
 


### PR DESCRIPTION
TL;DR: This PR aims to fix #46.

Hi Justin,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot 3.5.0 would  break ggside.
Given that other packages also import ggside we felt it was prudent to help out to transition to the new version.
The culprit is that ggplot2 has changed the guide system, see https://github.com/tidyverse/ggplot2/pull/4879.
This PR handles the new guide infrastructure and should work with both the current and the development version of ggplot2.
To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled at the end of January / early Februari. The progress can be tracked in https://github.com/tidyverse/ggplot2/issues/5588.
We are hoping that this PR might help ggside be ready around that time to soften the impact on downstream packages.